### PR TITLE
Group CodeQL action updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      # The init/autobuild/analyze steps must stay on the same version, so they
+      # have to be bumped in a single pull request.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
This PR groups CodeQL action updates in Dependabot to ensure that init/autobuild/analyze steps stay on the same version.

The init, autobuild, and analyze steps must stay on the same version, so they have to be bumped in a single pull request.

This change adds a `groups` configuration to `.github/dependabot.yml` that groups all `github/codeql-action*` updates together.

Related to: https://github.com/singlestore-labs/events/pull/192