### PR TITLE
Update Go version for macOS-latest compatibility

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.18'
+          go-version: '1.23'
       - name: Run coverage
         run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic -coverpkg github.com/muir/list
       - name: Upload coverage to Codecov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x, 1.26.x, 1.27.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/muir/list
 
-go 1.18
+go 1.23
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
Update Go version to 1.23+ for macOS-latest compatibility

macOS-latest runners no longer support Go 1.22 and below. This updates
the minimum Go version to 1.23 and tests through 1.27.

This PR updates the Go version to ensure compatibility with `macos-latest` in GitHub Actions, which no longer supports Go 1.22.

Changes:
- Updated `go.mod` to require Go 1.23 or higher
- Updated CI workflows to test against Go versions: 1.23.x, 1.24.x, 1.25.x, 1.26.x, 1.27.x
- Updated golangci-lint to use Go 1.23

This ensures the project works with current GitHub Actions runners.